### PR TITLE
fix `fixRef` function's issue with `mailto:` URL

### DIFF
--- a/extensions/chrome/hovercard.js
+++ b/extensions/chrome/hovercard.js
@@ -580,7 +580,7 @@ $(() => {
   function fixRef(elem, base, branch) {
     ['href', 'src'].forEach(attr => {
       let url = elem.attr(attr);
-      if (url && url.indexOf('//') === -1) {
+      if (url && url.indexOf('//') === -1 && url.indexOf('mailto:') === -1) {
         elem.attr(attr, `${base}/raw/${branch}/${url}`);
       }
     });

--- a/extensions/edge/hovercard.js
+++ b/extensions/edge/hovercard.js
@@ -580,7 +580,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function fixRef(elem, base, branch) {
     ['href', 'src'].forEach(attr => {
       let url = elem.attr(attr);
-      if (url && url.indexOf('//') === -1) {
+      if (url && url.indexOf('//') === -1 && url.indexOf('mailto:') === -1) {
         elem.attr(attr, `${base}/raw/${branch}/${url}`);
       }
     });

--- a/extensions/firefox/data/hovercard.js
+++ b/extensions/firefox/data/hovercard.js
@@ -580,7 +580,7 @@ $(() => {
   function fixRef(elem, base, branch) {
     ['href', 'src'].forEach(attr => {
       let url = elem.attr(attr);
-      if (url && url.indexOf('//') === -1) {
+      if (url && url.indexOf('//') === -1 && url.indexOf('mailto:') === -1) {
         elem.attr(attr, `${base}/raw/${branch}/${url}`);
       }
     });

--- a/extensions/github-hovercard.safariextension/hovercard.js
+++ b/extensions/github-hovercard.safariextension/hovercard.js
@@ -580,7 +580,7 @@ $(() => {
   function fixRef(elem, base, branch) {
     ['href', 'src'].forEach(attr => {
       let url = elem.attr(attr);
-      if (url && url.indexOf('//') === -1) {
+      if (url && url.indexOf('//') === -1 && url.indexOf('mailto:') === -1) {
         elem.attr(attr, `${base}/raw/${branch}/${url}`);
       }
     });

--- a/src/hovercard.js
+++ b/src/hovercard.js
@@ -580,7 +580,7 @@ $(() => {
   function fixRef(elem, base, branch) {
     ['href', 'src'].forEach(attr => {
       let url = elem.attr(attr);
-      if (url && url.indexOf('//') === -1) {
+      if (url && url.indexOf('//') === -1 && url.indexOf('mailto:') === -1) {
         elem.attr(attr, `${base}/raw/${branch}/${url}`);
       }
     });


### PR DESCRIPTION
When the README of a repo contain URL like this:

```
[contact me](mailto:email@gmail.com)
```

The generated hovercard will parse the URL to something like `https://github.com/username/reponame/raw/master/mailto:email@gmail.com`.

The problem is the `fixRef(elem, base, branch)` function didn't consider URLs containing `mailto:` 

I've fixed this issue in this PR. Please take a look ;)