### PR TITLE
fix: correct repo meta "Issues" to "Issues & PRs"

### DIFF
--- a/src/hovercard.js
+++ b/src/hovercard.js
@@ -370,7 +370,7 @@ $(() => {
             </a>
             {{#hasIssues}}<a href="{{issuesUrl}}">
               <strong>{{issues}}</strong>
-              <span>Issues</span>
+              <span>Issues & PRs</span>
             </a>{{/hasIssues}}
           </div>
           {{#desc}}<p class="ghh-repo-desc">{{{icons.info}}}{{{.}}}</p>{{/desc}}


### PR DESCRIPTION
The `issues` number is acutally open issues plus open PRs.