### PR TITLE
Updated to not include full width profile image

### DIFF
--- a/src/hovercard.js
+++ b/src/hovercard.js
@@ -554,7 +554,7 @@ $(() => {
 
     /* Common */
     // Avatars
-    'img.avatar:not([alt=""])': EXTRACTOR.ALT_USER,
+    'img.avatar:not([alt=""]):not(.width-full)': EXTRACTOR.ALT_USER,
     'img.gravatar:not([alt=""])': EXTRACTOR.ALT_USER,
 
     /* All links */


### PR DESCRIPTION
Fixes #152 

On profile pages, it is not necessary to show a hovercard for the user whose profile page you are currently viewing. Since the hovercard currently shows incorrect information, it seems it would be better to exclude full width profile images from the hovercards.